### PR TITLE
discovery: true 일때 KeyError: 'kor' 해결

### DIFF
--- a/sds_wallpad/sds_wallpad.py
+++ b/sds_wallpad/sds_wallpad.py
@@ -1096,8 +1096,6 @@ def serial_new_device(device, idn, packet):
         for payloads in DISCOVERY_PAYLOAD[device]:
             payload = payloads.copy()
             payload["~"] = payload["~"].format(prefix=prefix, idn=idn)
-            payload["name"] = payload["name"].format(idn=idn)
-            payload["obj_id"] = payload["obj_id"].format(prefix=prefix, idn=idn)
 
             # 실시간 에너지 사용량에는 적절한 이름과 단위를 붙여준다 (단위가 없으면 그래프로 출력이 안됨)
             if device == "energy":
@@ -1109,6 +1107,8 @@ def serial_new_device(device, idn, packet):
                 payload["val_tpl"] = "{{ value | float / {} }}".format(10 ** Options["rs485"]["{}_decimal".format(eng)])
                 if idn == 0:
                     payload["dev_cla"] = "power"
+            payload["name"] = payload["name"].format(idn=idn)
+            payload["obj_id"] = payload["obj_id"].format(prefix=prefix, idn=idn)
 
             mqtt_discovery(payload)
 


### PR DESCRIPTION
https://cafe.naver.com/koreassistant/17729 글 댓글의 "올팽스"님과 같은 증상이여서 확인해봤습니다.

`11:25:32 ERROR addon exception! ('kor')
Traceback (most recent call last):
File "/srv/[sds_wallpad.py](http://sds_wallpad.py/)", line 1379, in <module>
serial_loop()
File "/srv/[sds_wallpad.py](http://sds_wallpad.py/)", line 1259, in serial_loop
serial_receive_state(device, packet)
File "/srv/[sds_wallpad.py](http://sds_wallpad.py/)", line 1134, in serial_receive_state
serial_new_device(device, idn, packet)
File "/srv/[sds_wallpad.py](http://sds_wallpad.py/)", line 1099, in serial_new_device
payload["name"] = payload["name"].format(idn=idn)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'kor'
[Info] unexpected exit!`

코드를 다 확인해보진 않아서 좋은 해결방법일지는 모르겠지만, 일단 오류는 해결되고 정상적으로 동작합니다.